### PR TITLE
Retirado package-lock.yml do arquivo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 target/
 dbt_packages/
 logs/
-package-lock.yml


### PR DESCRIPTION
Retirado o arquivo package-lock de dentro do arquivo gitignore.